### PR TITLE
Item selection

### DIFF
--- a/src/examples/baby.svelte
+++ b/src/examples/baby.svelte
@@ -38,6 +38,7 @@
     filterInputAttributes,
     triggerButtonAttributes,
     highlightedIndex,
+    selectedItem,
     getItemProps,
     listItem,
   } = createCombobox({
@@ -48,9 +49,10 @@
     itemToString(item) {
       return item ? item.title : "";
     },
-    // onSelectedItemChange: ({selectedItem: newSelectedItem}) =>
-    //   setSelectedItem(newSelectedItem),
-    // });
+    selectItem: (item) => {
+      console.log(item);
+      // setSelectedItem(item),
+    },
   });
 </script>
 
@@ -89,12 +91,12 @@
         <li
           use:listItem
           class="item"
+          style:--font-weight={$selectedItem === item ? "700" : "400"}
           style:--background-color={$highlightedIndex === index
             ? "#eee"
             : "transparent"}
           {...getItemProps(index)}
         >
-          <!-- style:--font-weight={$selectedItem === item ? "700" : "400"} -->
           <span>{item.title}</span>
           <span class="item-author">{item.author}</span>
         </li>


### PR DESCRIPTION
Item selection involves a few mouse/keyboard events in order to work:

[x] on click
[x] on enter
[ ] on alt+arrow up

## Things to note

- Click events don't work due to blur events, so we need to use `mousedown`. This is problematic as the action can't be bailed out of by moving the mouse off of the item (it's immediate)  
- Clicking the item does not keep focus on the input, but targeting focus doesn't work due to the blur event

### Follow ups

Blur events should be removed. They cause way too many issues with bubbling/focus control.