### PR TITLE
Linting configuration improvements & type fixes

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,6 +3,7 @@ module.exports = {
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "plugin:svelte/recommended",
     "prettier",
   ],

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,10 +9,12 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint"],
   parserOptions: {
-    sourceType: "module",
     ecmaVersion: 2020,
     extraFileExtensions: [".svelte"],
+    project: "./tsconfig.json",
+    sourceType: "module",
   },
+  ignorePatterns: ["*.cjs", "svelte.config.js"],
   env: {
     browser: true,
     es2017: true,
@@ -22,9 +24,7 @@ module.exports = {
     {
       files: ["*.svelte"],
       parser: "svelte-eslint-parser",
-      parserOptions: {
-        parser: "@typescript-eslint/parser",
-      },
+      parserOptions: { parser: "@typescript-eslint/parser" },
     },
   ],
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,19 +1,22 @@
+/** @type {import("eslint").Linter.Config} */
 module.exports = {
   root: true,
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
-    "plugin:svelte/recommended",
     "prettier",
   ],
+  globals: {
+    svelte: "readonly",
+    $$Generic: "readonly",
+  },
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint"],
   parserOptions: {
-    ecmaVersion: 2020,
     extraFileExtensions: [".svelte"],
     project: "./tsconfig.json",
-    sourceType: "module",
+    tsconfigRootDir: __dirname,
   },
   ignorePatterns: ["*.cjs", "svelte.config.js"],
   env: {
@@ -21,11 +24,28 @@ module.exports = {
     es2017: true,
     node: true,
   },
+
   overrides: [
     {
       files: ["*.svelte"],
+      extends: ["plugin:svelte/recommended"],
       parser: "svelte-eslint-parser",
-      parserOptions: { parser: "@typescript-eslint/parser" },
+      parserOptions: {
+        parser: "@typescript-eslint/parser",
+      },
+      /**
+       * There are quite a few @typescript-eslint rules that don't work
+       * well in Svelte <script> blocks and introduce false positives.
+       * @see https://github.com/CaptainCodeman/svelte-headlessui/blob/master/packages/lib/.eslintrc.cjs
+       */
+      rules: {
+        "@typescript-eslint/no-unnecessary-condition": "off",
+        "@typescript-eslint/no-unsafe-argument": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-call": "off",
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/restrict-template-expressions": "off",
+      },
     },
   ],
 };

--- a/src/examples/baby.svelte
+++ b/src/examples/baby.svelte
@@ -2,7 +2,12 @@
   import { writable } from "svelte/store";
   import { createCombobox } from "$lib/index.js";
 
-  const books = [
+  interface Book {
+    author: string;
+    title: string;
+  }
+
+  const books: Book[] = [
     { author: "Harper Lee", title: "To Kill a Mockingbird" },
     { author: "Lev Tolstoy", title: "War and Peace" },
     { author: "Fyodor Dostoyevsy", title: "The Idiot" },
@@ -20,7 +25,7 @@
   function getBooksFilter(inputValue: string) {
     const lowerCasedInputValue = inputValue.toLowerCase();
 
-    return function booksFilter(book: any) {
+    return function booksFilter(book: Book) {
       return (
         !inputValue ||
         book.title.toLowerCase().includes(lowerCasedInputValue) ||

--- a/src/lib/create-combobox.ts
+++ b/src/lib/create-combobox.ts
@@ -15,8 +15,7 @@ import type {
   HTMLLiAttributes,
 } from "svelte/elements";
 
-type Item = Record<string, unknown>;
-interface ComboboxProps<T extends Item> {
+interface ComboboxProps<T> {
   items: Writable<T[]>;
   /** @see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#block */
   scrollAlignment?: "nearest" | "center";
@@ -53,7 +52,7 @@ interface Combobox<T> {
  * [ ] Item selection
  * [ ] `esc` keybind to (1) close the menu and (2) then clear the input.
  */
-export function createCombobox<T extends Item>({
+export function createCombobox<T>({
   items,
   scrollAlignment = "nearest",
   itemToString,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,11 +1,10 @@
-<script>
+<script lang="ts">
+  import type { NavbarConfig } from "@svelteness/kit-docs";
   import "@svelteness/kit-docs/client/polyfills/index.js";
   import "@svelteness/kit-docs/client/styles/normalize.css";
   import "@svelteness/kit-docs/client/styles/theme.css";
   import "@svelteness/kit-docs/client/styles/vars.css";
-
   import { page } from "$app/stores";
-
   import {
     Button,
     KitDocs,
@@ -17,8 +16,7 @@
 
   $: ({ meta, sidebar } = data);
 
-  /** @type {import('@svelteness/kit-docs').NavbarConfig} */
-  const navbar = {
+  const navbar: NavbarConfig = {
     links: [{ title: "Documentation", slug: "/docs", match: /\/docs/ }],
   };
 


### PR DESCRIPTION
This PR makes a couple improvements to our ESLint configuration:

- It enables type-aware linting via the `@typescript-eslint/recommended-requiring-type-checking` preset.
- Scopes `eslint-plugin-svelte` to only `*.svelte` files and disables incompatible rules from the recommended-requiring-type-checking preset.


Tweaking the ESLint configuration surfaced some minor issues that I cleaned up:

- The `ComboboxProps<T extends Item>` extension of the `Item` type was getting in the way of correct type inference. The `extends Item` narrowing was removed and the fix was validated by typing the `Books[]` array in the example component.
- Replaced JSDoc `@type {}` imports in favor of TypeScript type imports in `.ts` files.