### PR TITLE
Improve `backspace` handling when the menu is closed

### DIFF
--- a/src/lib/create-combobox.ts
+++ b/src/lib/create-combobox.ts
@@ -191,7 +191,7 @@ export function createCombobox<T>({
     }
 
     function handleKeydown(e: KeyboardEvent) {
-      // Handle key events when the menu is open.
+      // Handle key events when the menu is closed.
       if (!$store.isOpen) {
         // The user presses `esc`. The input should be cleared and lose focus.
         if (e.key === keyboardKeys.Escape) {


### PR DESCRIPTION
Resolves https://github.com/Vpr99/svelte-drop/issues/20

---

When hitting `backspace` when the menu is closed, it now checks to see if the input value is blank (`""`) before opening the menu.